### PR TITLE
Adds foundation and create subcommands

### DIFF
--- a/MazeGenerator/.gitignore
+++ b/MazeGenerator/.gitignore
@@ -1,1 +1,2 @@
 /target/**
+/target/

--- a/MazeGenerator/src/main/java/com/karbonhq/games/minecraft/mazegenerator/MazeGeneratorPlugin.java
+++ b/MazeGenerator/src/main/java/com/karbonhq/games/minecraft/mazegenerator/MazeGeneratorPlugin.java
@@ -4,23 +4,15 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import com.karbonhq.games.minecraft.mazegenerator.commands.MazegenCommand;
+
 public final class MazeGeneratorPlugin extends JavaPlugin {
 	@Override
 	public void onEnable() {
+		this.getCommand("mazegen").setExecutor(new MazegenCommand(this));
 	}
 	
 	@Override
 	public void onDisable() {
-	}
-	
-	@Override
-	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args)
-	{
-		if (cmd.getName().equalsIgnoreCase("mazegen"))
-		{
-			sender.sendMessage("Congratulations, you invoked mazegen! It does nothing yet, though.");
-			return true;
-		}
-		return false;
 	}
 }

--- a/MazeGenerator/src/main/java/com/karbonhq/games/minecraft/mazegenerator/commands/CreateCommand.java
+++ b/MazeGenerator/src/main/java/com/karbonhq/games/minecraft/mazegenerator/commands/CreateCommand.java
@@ -1,0 +1,301 @@
+package com.karbonhq.games.minecraft.mazegenerator.commands;
+
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Directional;
+import org.bukkit.block.data.type.Door;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.util.RayTraceResult;
+
+import com.karbonhq.games.minecraft.mazegenerator.MazeGeneratorPlugin;
+
+import net.md_5.bungee.api.ChatColor;
+
+public class CreateCommand implements CommandExecutor {
+	private final MazeGeneratorPlugin plugin;
+
+	public CreateCommand(MazeGeneratorPlugin plugin)
+	{
+		this.plugin = plugin;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		Player player = (Player) sender;
+		World world = player.getWorld();
+		RayTraceResult lookingAt = player.rayTraceBlocks(10);
+		Block hitBlock = (lookingAt != null ? lookingAt.getHitBlock() : null);
+
+		if (hitBlock == null) {
+			sender.sendMessage(ChatColor.RED + "You must be looking at a maze foundation within 10 blocks.");
+			sendUsage(sender);
+			return true;
+		}
+
+		int[] foundationDimensions = findBestRectangle(world, hitBlock);
+		if (foundationDimensions.length == 0) {
+			sender.sendMessage(ChatColor.RED + "You must be looking at a square of at least 3x3.");
+			sendUsage(sender);
+			return true;
+		}
+
+		placeOuterWalls(world, hitBlock, foundationDimensions);
+		placeRoof(world, hitBlock, foundationDimensions);
+		placeInsides(world, hitBlock, foundationDimensions);
+
+		return true;
+	}
+
+	private void sendUsage(CommandSender sender) {
+		sender.sendMessage("Usage: /mazegen create");
+		sender.sendMessage("Creates a maze on the foundation the player is looking at. The walls and roof will be made of the same material as the foundation.");
+		sender.sendMessage("Doors placed on the edges of the maze area will be left intact and torches placed next to them.");
+		sender.sendMessage("All existing blocks inside the maze will be destroyed.");
+	}
+
+	private int[] findBestRectangle(World world, Block hitBlock) {
+		int baseX = hitBlock.getX();
+		int baseY = hitBlock.getY();
+		int baseZ = hitBlock.getZ();
+		Material baseType = hitBlock.getType();
+		Block targetBlock;
+
+		// Start by finding the biggest square centered on the target
+		int squareRadius = 0;
+		boolean foundMinXEdge = false;
+		boolean foundMaxXEdge = false;
+		boolean foundMinZEdge = false;
+		boolean foundMaxZEdge = false;
+
+		// TODO: Arbitrary maximum size of 30
+		while (squareRadius < 30 && !(
+			foundMinXEdge || foundMaxXEdge || foundMinZEdge || foundMaxZEdge
+		)) {
+			squareRadius++;
+			// Check first row
+			for (int x = baseX - squareRadius; x <= baseX + squareRadius; x++) {
+				targetBlock = world.getBlockAt(x, baseY, baseZ - squareRadius);
+				if (targetBlock.getType() != baseType) {
+					foundMinZEdge = true;
+					break;
+				}
+			}
+
+			// Check last row
+			for (int x = baseX - squareRadius; x <= baseX + squareRadius; x++) {
+				targetBlock = world.getBlockAt(x, baseY, baseZ + squareRadius);
+				if (targetBlock.getType() != baseType) {
+					foundMaxZEdge = true;
+					break;
+				}
+			}
+
+			// Check first column
+			for (int z = baseZ - squareRadius; z <= baseZ + squareRadius; z++) {
+				targetBlock = world.getBlockAt(baseX - squareRadius, baseY, z);
+				if (targetBlock.getType() != baseType) {
+					foundMinXEdge = true;
+					break;
+				}
+			}
+
+			// Check last column
+			for (int z = baseZ - squareRadius; z <= baseZ + squareRadius; z++) {
+				targetBlock = world.getBlockAt(baseX + squareRadius, baseY, z);
+				if (targetBlock.getType() != baseType) {
+					foundMaxXEdge = true;
+					break;
+				}
+			}
+		}
+		squareRadius--;
+		if (squareRadius < 1)
+			return new int[0];
+
+		int minX = baseX - squareRadius;
+		int maxX = baseX + squareRadius;
+		int minZ = baseZ - squareRadius;
+		int maxZ = baseZ + squareRadius;
+
+		// Arbitrarily try to grow in -X, +X, -Z, +Z
+		foundMinXEdge = false;
+		while (!foundMinXEdge) {
+			minX--;
+			for (int z = minZ; z <= maxZ; z++) {
+				targetBlock = world.getBlockAt(minX, baseY, z);
+				if (targetBlock.getType() != baseType) {
+					foundMinXEdge = true;
+					break;
+				}
+			}
+		}
+		minX++;
+
+		foundMaxXEdge = false;
+		while (!foundMaxXEdge) {
+			maxX++;
+			for (int z = minZ; z <= maxZ; z++) {
+				targetBlock = world.getBlockAt(maxX, baseY, z);
+				if (targetBlock.getType() != baseType) {
+					foundMaxXEdge = true;
+					break;
+				}
+			}
+		}
+		maxX--;
+
+		foundMinZEdge = false;
+		while (!foundMinZEdge) {
+			minZ--;
+			for (int x = minX; x <= maxX; x++) {
+				targetBlock = world.getBlockAt(x, baseY, minZ);
+				if (targetBlock.getType() != baseType) {
+					foundMinZEdge = true;
+					break;
+				}
+			}
+		}
+		minZ++;
+
+		foundMaxZEdge = false;
+		while (!foundMaxZEdge) {
+			maxZ++;
+			for (int x = minX; x <= maxX; x++) {
+				targetBlock = world.getBlockAt(x, baseY, maxZ);
+				if (targetBlock.getType() != baseType) {
+					foundMaxZEdge = true;
+					break;
+				}
+			}
+		}
+		maxZ--;
+
+		return new int[] { minX, maxX, minZ, maxZ };
+	}
+
+	private void placeOuterWalls(World world, Block hitBlock, int[] foundationDimensions) {
+		int minX = foundationDimensions[0];
+		int maxX = foundationDimensions[1];
+		int baseY = hitBlock.getY();
+		int minZ = foundationDimensions[2];
+		int maxZ = foundationDimensions[3];
+		Block targetBlock;
+
+		for (int y = 1; y <= 2; y++)
+		{
+			// Place walls (leaving doors alone)
+			for (int x = minX; x <= maxX; x++) {
+				targetBlock = world.getBlockAt(x, baseY + y, minZ);
+				if (isDoor(targetBlock)) {
+					if (y == 2) {
+						if (x > minX && !isDoor(world, x - 1, baseY + y, minZ)) {
+							placeTorch(world, x - 1, baseY + y, minZ - 1, BlockFace.NORTH);
+						}
+						if (x < maxX && !isDoor(world, x + 1, baseY + y, minZ)) {
+							placeTorch(world, x + 1, baseY + y, minZ - 1, BlockFace.NORTH);
+						}
+					}
+				} else
+					targetBlock.setType(hitBlock.getType());
+
+				targetBlock = world.getBlockAt(x, baseY + y, maxZ);
+				if ((targetBlock.getBlockData() instanceof Door)) {
+					if (y == 2) {
+						if (x > minX && !isDoor(world, x - 1, baseY + y, maxZ)) {
+							placeTorch(world, x - 1, baseY + y, maxZ + 1, BlockFace.SOUTH);
+						}
+						if (x < maxX && !isDoor(world, x + 1, baseY + y, maxZ)) {
+							placeTorch(world, x + 1, baseY + y, maxZ + 1, BlockFace.SOUTH);
+						}
+					}
+				} else
+					targetBlock.setType(hitBlock.getType());
+			}
+
+			for (int z = minZ; z <= maxZ; z++) {
+				targetBlock = world.getBlockAt(minX, baseY + y, z);
+				if ((targetBlock.getBlockData() instanceof Door)) {
+					if (y == 2) {
+						if (z > minZ && !isDoor(world, minX, baseY + y, z - 1)) {
+							placeTorch(world, minX - 1, baseY + y, z - 1, BlockFace.WEST);
+						}
+						if (z < maxZ && !isDoor(world, minX, baseY + y, z + 1)) {
+							placeTorch(world, minX - 1, baseY + y, z + 1, BlockFace.WEST);
+						}
+					}
+				} else
+					targetBlock.setType(hitBlock.getType());
+
+				targetBlock = world.getBlockAt(maxX, baseY + y, z);
+				if ((targetBlock.getBlockData() instanceof Door)) {
+					if (y == 2) {
+						if (z > minZ && !isDoor(world, maxX, baseY + y, z - 1)) {
+							placeTorch(world, maxX + 1, baseY + y, z - 1, BlockFace.EAST);
+						}
+						if (z < maxZ && !isDoor(world, maxX, baseY + y, z + 1)) {
+							placeTorch(world, maxX + 1, baseY + y, z + 1, BlockFace.EAST);
+						}
+					}
+				} else
+					targetBlock.setType(hitBlock.getType());
+			}
+		}
+	}
+
+	private boolean isDoor(Block targetBlock) {
+		return (targetBlock.getBlockData() instanceof Door);
+	}
+
+	private boolean isDoor(World world, int x, int y, int z) {
+		return isDoor(world.getBlockAt(x, y, z));
+	}
+
+	private void placeTorch(World world, int x, int y, int z, BlockFace blockFace) {
+		Block torchBlock = world.getBlockAt(x, y, z);
+		if (!(torchBlock.getType() == Material.AIR))
+			return;
+
+		torchBlock.setType(Material.WALL_TORCH);
+		Directional torchDirection = (Directional) torchBlock.getBlockData();
+		torchDirection.setFacing(blockFace);
+		torchBlock.setBlockData(torchDirection);
+	}
+
+	private void placeRoof(World world, Block hitBlock, int[] foundationDimensions) {
+		int minX = foundationDimensions[0];
+		int maxX = foundationDimensions[1];
+		int baseY = hitBlock.getY();
+		int minZ = foundationDimensions[2];
+		int maxZ = foundationDimensions[3];
+		Block targetBlock;
+
+		for (int x = minX; x <= maxX; x++)
+			for (int z = minZ; z <= maxZ; z++) {
+				targetBlock = world.getBlockAt(x, baseY + 3, z);
+				targetBlock.setType(hitBlock.getType());
+			}
+	}
+
+	private void placeInsides(World world, Block hitBlock, int[] foundationDimensions) {
+		int minX = foundationDimensions[0];
+		int maxX = foundationDimensions[1];
+		int baseY = hitBlock.getY();
+		int minZ = foundationDimensions[2];
+		int maxZ = foundationDimensions[3];
+		Block targetBlock;
+
+		for (int y = 1; y <= 2; y++)
+			for (int x = minX + 1; x < maxX; x++)
+				for (int z = minZ + 1; z < maxZ; z++) {
+					targetBlock = world.getBlockAt(x, baseY + y, z);
+					targetBlock.setType(Material.AIR);
+				}
+
+		// TODO: Make an actual maze
+	}
+}

--- a/MazeGenerator/src/main/java/com/karbonhq/games/minecraft/mazegenerator/commands/FoundationCommand.java
+++ b/MazeGenerator/src/main/java/com/karbonhq/games/minecraft/mazegenerator/commands/FoundationCommand.java
@@ -1,0 +1,154 @@
+package com.karbonhq.games.minecraft.mazegenerator.commands;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.BlockFace;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import com.karbonhq.games.minecraft.mazegenerator.MazeGeneratorPlugin;
+
+import net.md_5.bungee.api.ChatColor;
+
+public class FoundationCommand implements CommandExecutor {
+	private final MazeGeneratorPlugin plugin;
+
+	public FoundationCommand(MazeGeneratorPlugin plugin)
+	{
+		this.plugin = plugin;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		int[] depthWidth = parseArgs(args);
+
+		if (depthWidth.length < 2) {
+			sendUsage(sender);
+			return true;
+		}
+
+		int depth = depthWidth[0];
+		int width = depthWidth[1];
+
+		Player player = (Player) sender;
+		World world = player.getWorld();
+		if (player.isFlying()) {
+			sender.sendMessage(ChatColor.RED + "You must be standing on the block you want to start from (not flying).");
+			sendUsage(sender);
+			return true;
+		}
+
+		BlockFace face = player.getFacing();
+		BlockFace faceRight;
+		switch(face) {
+			case NORTH:
+				faceRight = BlockFace.EAST;
+				break;
+
+			case EAST:
+				faceRight = BlockFace.SOUTH;
+				break;
+
+			case SOUTH:
+				faceRight = BlockFace.WEST;
+				break;
+
+			case WEST:
+				faceRight = BlockFace.NORTH;
+				break;
+
+			default:
+				sender.sendMessage(String.format(ChatColor.RED + "Couldn't figure out your facing, got %s", face.toString()));
+				return true;
+		}
+
+		Location rootLocation = getPlayerStandOnBlockLocation(player.getLocation().add(0,-1,0));
+
+		int forwardX = face.getModX();
+		int forwardZ = face.getModZ();
+		int rightX = faceRight.getModX();
+		int rightZ = faceRight.getModZ();
+
+		Material foundationMaterial = Material.BEDROCK;
+		ItemStack heldItemStack = player.getInventory().getItemInMainHand();
+		if (heldItemStack != null) {
+			Material heldItem = heldItemStack.getType();
+			if (heldItem.isSolid())
+				foundationMaterial = heldItem;
+		}
+
+		for (int depthIndex = 0; depthIndex < depth; depthIndex++) {
+			for (int widthIndex = 0; widthIndex < width; widthIndex++) {
+				Location target = rootLocation.clone();
+				target.add(
+					forwardX * depthIndex + rightX * widthIndex,
+					0,
+					forwardZ * depthIndex + rightZ * widthIndex);
+				world.getBlockAt(target).setType(foundationMaterial);
+			}
+		}
+
+		return true;
+	}
+
+	private void sendUsage(CommandSender sender) {
+		sender.sendMessage("Usage: /mazegen foundation [width] [height]");
+		sender.sendMessage("Places a floor of [width]x[height], starting from the block you are standing on and extending ahead and to the right.");
+		sender.sendMessage("If you are holding a block, the foundation will be made of that block; if you are not holding a block, it will be made of bedrock.");
+	}
+
+    private static Location getPlayerStandOnBlockLocation(Location locationUnderPlayer)
+    {
+        Location b11 = locationUnderPlayer.clone().add(0.3,0,-0.3);
+        if (b11.getBlock().getType() != Material.AIR)
+        {
+            return b11;
+        }
+        Location b12 = locationUnderPlayer.clone().add(-0.3,0,-0.3);
+        if (b12.getBlock().getType() != Material.AIR)
+        {
+            return b12;
+        }
+        Location b21 = locationUnderPlayer.clone().add(0.3,0,0.3);
+        if (b21.getBlock().getType() != Material.AIR)
+        {
+            return b21;
+        }
+        Location b22 = locationUnderPlayer.clone().add(-0.3,0,+0.3);
+        if (b22.getBlock().getType() != Material.AIR)
+        {
+            return b22;
+        }
+        return locationUnderPlayer;
+    }
+
+    private static int[] parseArgs(String[] args) {
+		if (args.length < 3) {
+			return new int[0];
+		}
+
+		int depth = -1;
+		int width = -1;
+
+		try {
+			depth = Integer.parseInt(args[1]);
+			width = Integer.parseInt(args[2]);
+		} catch (NumberFormatException ex) {
+			// Do nothing, we just assume it didn't parse
+			return new int[0];
+		}
+
+		if (depth < 3 || width < 3) {
+			return new int[0];
+		}
+
+		int[] depthWidth = new int[2];
+		depthWidth[0] = depth;
+		depthWidth[1] = width;
+		return depthWidth;
+	}
+}

--- a/MazeGenerator/src/main/java/com/karbonhq/games/minecraft/mazegenerator/commands/MazegenCommand.java
+++ b/MazeGenerator/src/main/java/com/karbonhq/games/minecraft/mazegenerator/commands/MazegenCommand.java
@@ -1,0 +1,48 @@
+package com.karbonhq.games.minecraft.mazegenerator.commands;
+
+import org.bukkit.GameMode;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.karbonhq.games.minecraft.mazegenerator.MazeGeneratorPlugin;
+
+public class MazegenCommand implements CommandExecutor {
+	private final MazeGeneratorPlugin plugin;
+
+	public MazegenCommand(MazeGeneratorPlugin plugin)
+	{
+		this.plugin = plugin;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		if (!(sender instanceof Player))
+		{
+			sender.sendMessage("Only players can generate mazes.");
+			return false;
+		}
+		Player player = (Player)sender;
+		if (player.getGameMode() != GameMode.CREATIVE) {
+			sender.sendMessage("You must be in creative mode to create a maze.");
+			return false;
+		}
+
+		if (args.length < 1) {
+			return false;
+		}
+
+		switch(args[0].toLowerCase()) {
+			case "foundation":
+				return new FoundationCommand(this.plugin).onCommand(sender, command, label, args);
+
+			case "create":
+				return new CreateCommand(this.plugin).onCommand(sender, command, label, args);
+
+			default:
+				// Unrecognized command
+				return false;
+		}
+	}
+}

--- a/MazeGenerator/src/main/resources/plugin.yml
+++ b/MazeGenerator/src/main/resources/plugin.yml
@@ -1,7 +1,9 @@
 name: MazeGeneratorPlugin
 main: com.karbonhq.games.minecraft.mazegenerator.MazeGeneratorPlugin
 version: 0.0.1-SNAPSHOT
+api-version: 1.13
 commands:
   mazegen:
-    description: Generates a maze. When it's done, anyway.
-    usage: /mazegen
+    description: Generates a maze.
+    usage: |
+      /<command> [foundation | create]


### PR DESCRIPTION
The following commands are added:

* `/mazegen foundation [depth] [width]`
  Creates a foundation of blocks starting under the player's feet, extending `depth` blocks ahead of them and `width` blocks to the right. `depth` and `width` must be at least 3. If the player is holding a placeable block, the foundation will be made from it; otherwise, the foundation will be bedrock.

* `/mazegen create`
  Attempts to create a maze using the block the player is looking at as a foundation. It will try to find the biggest rectangle of contiguous squares made of the same material (the `foundation` subcommand is a good way to create such a thing). The maze will be made of the same material as the foundation and extend two squares high. Existing blocks inside the maze area will be destroyed, except for doors on the boundary of the rectangle. Such doors will be preserved and torches placed alongside them.